### PR TITLE
Fix test mkdir touch

### DIFF
--- a/spec/packages/cd_spec.rb
+++ b/spec/packages/cd_spec.rb
@@ -2,6 +2,10 @@ require "packages/cd"
 
 describe Cd do
 
+  before :all do
+    @old_path = Dir.pwd
+  end
+  
   describe ".main" do
     context "given existing directory" do
       it "CDs into the directory" do
@@ -14,9 +18,8 @@ describe Cd do
   describe ".main" do
     context "given non-existent directory" do
       it "does not change directory" do
-        old_path = Dir.pwd
         Cd.main(["does-not-exist"])
-        expect(Dir.pwd).to eql(old_path)
+        expect(Dir.pwd).to eql(@old_path)
       end
     end
   end
@@ -24,11 +27,14 @@ describe Cd do
   describe ".main" do
     context "given a file" do
       it "does not change directory" do
-        old_path = Dir.pwd
         Cd.main(["lib/packages/cd.rb"])
-        expect(Dir.pwd).to eql(old_path)
+        expect(Dir.pwd).to eql(@old_path)
       end
     end
+  end
+
+  after :each do
+    Cd.main([@old_path])
   end
 
 end

--- a/spec/packages/touch_spec.rb
+++ b/spec/packages/touch_spec.rb
@@ -15,7 +15,7 @@ describe Touch do
     context "given existing file" do
       it "does nothing" do
         File.write("touch.test", "")
-        expect(Touch.main("touch.test")).to eql(puts "")
+        expect(Touch.main(["touch.test"])).to eql(puts "")
         `rm touch.test`
       end
     end


### PR DESCRIPTION
'cd / home' caused a dependency between the tests. It is added to back to the previous directory before each test.
There are missing brackets in the test.